### PR TITLE
Fix short address decoding

### DIFF
--- a/plasma/contracts/RLPDecode.sol
+++ b/plasma/contracts/RLPDecode.sol
@@ -398,18 +398,12 @@ library RLPDecode {
         pure
         returns (address data)
     {
-        if (!isData(self)) {
-            revert();
-        }
-        uint rStartPos;
         uint len;
-        (rStartPos, len) = _decode(self);
-        if (len != 20) {
+        (, len) = _decode(self);
+        if (len > 20) {
             revert();
         }
-        assembly {
-            data := div(mload(rStartPos), exp(256, 12))
-        }
+        return address(toUint(self));
     }
 
 


### PR DESCRIPTION
Example addresses:
```
0x0014F55A50b281EFD12294f0Cda821Bd8171e920
0x0000000000000000000000000000000000000000
```